### PR TITLE
use user's locale

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -105,8 +105,8 @@ PlasmoidItem {
                 id: dayLabel
                 visible: plasmoid.configuration.showDayDisplay
                 anchors.centerIn: parent
-
-                text: Qt.formatDate(currentDateTime, "dddd")
+                
+                text: currentDateTime.toLocaleString(Qt.locale(), "dddd")
 
                 color: plasmoid.configuration.dayFontColor
                 font.family: if (plasmoid.configuration.dayFontFamily === "ccdefault") fontSmooch.name
@@ -131,7 +131,7 @@ PlasmoidItem {
             visible: plasmoid.configuration.showDateDisplay
             Layout.alignment: Qt.AlignHCenter
 
-            text: Qt.formatDate(currentDateTime, plasmoid.configuration.dateCustomDateFormat)
+            text: currentDateTime.toLocaleString(Qt.locale(), plasmoid.configuration.dateCustomDateFormat)
 
             color: plasmoid.configuration.dateFontColor
             font.family: if (plasmoid.configuration.dateFontFamily === "ccdefault") fontOutfitRegular.name


### PR DESCRIPTION
Hi qewer!

Could we use user's locale in this widget? This way 'day of the week' overlay text and 'month' will be displayed in user's language. 

Trade off is a weak support of writing systems in 'Outfit' and 'Smooch' fonts. Both of them doesn't support anything but 'Latin' char set.

Thank you for this work!